### PR TITLE
Change simulate to return signed_bundled_transactions

### DIFF
--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -172,7 +172,7 @@ class Flashbots(ModuleV2):
         )
 
         return {
-            "signed_bundled_transactions": signed_bundled_transactions,
+            "signedBundledTransactions": signed_bundled_transactions,
             "bundleHash": call_result["bundleHash"],
             "coinbaseDiff": call_result["coinbaseDiff"],
             "results": call_result["results"],

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -172,10 +172,10 @@ class Flashbots(ModuleV2):
         )
 
         return {
-            "signedBundledTransactions": signed_bundled_transactions,
             "bundleHash": call_result["bundleHash"],
             "coinbaseDiff": call_result["coinbaseDiff"],
             "results": call_result["results"],
+            "signedBundledTransactions": signed_bundled_transactions,
             "totalGasUsed": reduce(
                 lambda a, b: a + b["gasUsed"], call_result["results"], 0
             ),

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -172,6 +172,7 @@ class Flashbots(ModuleV2):
         )
 
         return {
+            "signed_bundled_transactions": signed_bundled_transactions,
             "bundleHash": call_result["bundleHash"],
             "coinbaseDiff": call_result["coinbaseDiff"],
             "results": call_result["results"],


### PR DESCRIPTION
I think this could be helpful. This way you can build an unsigned bundle, call simulate, check results, then send_bundle_munger(signed_bundled_transactions, ...). 

Without this, you can pass the unsigned bundle to send_bundle_munger, but it has to sign things twice then.