### PR TITLE
Update flashbots provider to read default endpoint during init

### DIFF
--- a/flashbots/provider.py
+++ b/flashbots/provider.py
@@ -23,11 +23,12 @@ class FlashbotProvider(HTTPProvider):
     def __init__(
         self,
         signature_account: LocalAccount,
-        endpoint_uri: Optional[Union[URI, str]] = get_default_endpoint(),
+        endpoint_uri: Optional[Union[URI, str]] = None,
         request_kwargs: Optional[Any] = None,
         session: Optional[Any] = None,
     ):
-        super().__init__(endpoint_uri, request_kwargs, session)
+        _endpoint_uri = endpoint_uri or get_default_endpoint()
+        super().__init__(_endpoint_uri, request_kwargs, session)
         self.signature_account = signature_account
 
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:


### PR DESCRIPTION
Update provider to read default endpoint at function call time (instead of import time).

This way, `endpoint_uri` can be set after importing the library, thus avoiding awkward patterns such as:

```
# Set environment conditionally on something.
 if chain_id == 1:
     ...
 elif chain_id == 5:
     os.environ['FLASHBOTS_HTTP_PROVIDER_URI'] = 'https://relay-goerli.flashbots.net/'
 else:
     raise NotImplementedError(f'Invalid chain: {chain_id}')

# Only then you can import the library.
from flashbots import flashbot
```