### PR TITLE
pin down the web3 version to 5.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Georgios Konstantopoulos <me@gakonst.com>", "Nikolas Papaioannou <n0
 
 [tool.poetry.dependencies]
 python = "^3.9"
-web3 = "^5.17.0"
+web3 = "~5.17.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
web3's 5.19.0 renames ModuleV2 to Module in this commit:

See this link: https://github.com/ethereum/web3.py/commit/910f62586b41e292dce11d4a1be61a575df0f23f

  commit 910f62586b41e292dce11d4a1be61a575df0f23f
  Author: kclowes <kclowes@users.noreply.github.com>
  Date:   Mon Apr 26 14:00:48 2021 -0600

      Rename ModuleV2 to Module