### PR TITLE
Don't re-estimate gas if transaction already contains gas field

### DIFF
--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -85,7 +85,8 @@ class Flashbots(ModuleV2):
                 # and update the tx details
                 tx["from"] = signer.address
                 tx["gasPrice"] = 0
-                tx["gas"] = self.web3.eth.estimateGas(tx)
+                if "gas" not in tx:
+                    tx["gas"] = self.web3.eth.estimateGas(tx)
                 # sign the tx
                 signed_tx = signer.sign_transaction(tx)
                 signed_transactions.append(signed_tx.rawTransaction)


### PR DESCRIPTION
sign_bundle current tries to re-estimate the gas, even if the user has explicitly set the gas amount. This patch makes sign_bundle only call estimateGas if the transaction doesn't have the gas set.