### PR TITLE
Added support for transactions expressed as dictionaries

### DIFF
--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -12,7 +12,7 @@ from .types import (
     FlashbotsOpts,
     FlashbotsBundleRawTx,
     FlashbotsBundleTx,
-    FlashbotsBundleDictTx
+    FlashbotsBundleDictTx,
 )
 import time
 
@@ -121,7 +121,7 @@ class Flashbots(ModuleV2):
 
     def to_hex(self, signed_transaction: bytes) -> str:
         tx_hex = signed_transaction.hex()
-        if tx_hex[0:2] != '0x':
+        if tx_hex[0:2] != "0x":
             tx_hex = f"0x{tx_hex}"
         return tx_hex
 
@@ -144,8 +144,7 @@ class Flashbots(ModuleV2):
         ]
 
     sendRawBundle: Method[Callable[[Any], Any]] = Method(
-        FlashbotsRPC.eth_sendBundle,
-        mungers=[send_raw_bundle_munger],
+        FlashbotsRPC.eth_sendBundle, mungers=[send_raw_bundle_munger]
     )
     send_raw_bundle = sendRawBundle
 
@@ -247,6 +246,5 @@ class Flashbots(ModuleV2):
         return inpt
 
     call_bundle: Method[Callable[[Any], Any]] = Method(
-        json_rpc_method=FlashbotsRPC.eth_callBundle,
-        mungers=[call_bundle_munger],
+        json_rpc_method=FlashbotsRPC.eth_callBundle, mungers=[call_bundle_munger]
     )

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -110,7 +110,7 @@ class Flashbots(ModuleV2):
                         gas=tx["gas"],
                         gasPrice=tx["gasPrice"],
                         nonce=tx["nonce"],
-                        to=HexBytes(tx["to"]),
+                        to=HexBytes(tx["to"]) if "to" in tx else None,
                         value=tx["value"],
                     ),
                     (v, r, s),

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -119,6 +119,12 @@ class Flashbots(ModuleV2):
 
         return signed_transactions
 
+    def to_hex(self, signed_transaction: bytes) -> str:
+        tx_hex = signed_transaction.hex()
+        if tx_hex[0:2] != '0x':
+            tx_hex = f"0x{tx_hex}"
+        return tx_hex
+
     def send_raw_bundle_munger(
         self,
         signed_bundled_transactions: List[HexBytes],
@@ -129,7 +135,7 @@ class Flashbots(ModuleV2):
         # convert to hex
         return [
             {
-                "txs": list(map(lambda x: x.hex(), signed_bundled_transactions)),
+                "txs": list(map(lambda x: self.to_hex(x), signed_bundled_transactions)),
                 "blockNumber": hex(target_block_number),
                 "minTimestamp": opts["minTimestamp"] if opts else 0,
                 "maxTimestamp": opts["maxTimestamp"] if opts else 0,

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -6,8 +6,14 @@ from web3.module import ModuleV2
 from web3.types import RPCEndpoint, Nonce, _Hash32
 from typing import Any, List, Optional, Callable, Union
 from functools import reduce
+from eth_account._utils.legacy_transactions import Transaction, encode_transaction
 
-from .types import FlashbotsOpts, FlashbotsBundleRawTx, FlashbotsBundleTx
+from .types import (
+    FlashbotsOpts,
+    FlashbotsBundleRawTx,
+    FlashbotsBundleTx,
+    FlashbotsBundleDictTx
+)
 import time
 
 SECONDS_PER_BLOCK = 15
@@ -57,19 +63,17 @@ class Flashbots(ModuleV2):
 
     def sign_bundle(
         self,
-        bundled_transactions: List[Union[FlashbotsBundleTx, FlashbotsBundleRawTx]],
+        bundled_transactions: List[
+            Union[FlashbotsBundleTx, FlashbotsBundleRawTx, FlashbotsBundleDictTx]
+        ],
     ) -> List[HexBytes]:
         """ Given a bundle of signed and unsigned transactions, it signs them all"""
         nonces = {}
         signed_transactions = []
         for tx in bundled_transactions:
-            # if it's not given a signer, we assume it's a signed RLP encoded tx,
-            if "signer" not in tx:
-                # TODO: Figure out how to decode a raw transaction with RLP
-                # decoded_tx = rlp.decode(tx["signed_transaction"], sedes=BaseTransactionFields)
-                # nonces[decoded_tx["from"]] = decoded_tx["nonce"] + 1
+            if "signed_transaction" in tx:
                 signed_transactions.append(tx["signed_transaction"])
-            else:
+            elif "signer" in tx:
                 # set all the fields
                 signer = tx["signer"]
                 tx = tx["transaction"]
@@ -90,6 +94,28 @@ class Flashbots(ModuleV2):
                 # sign the tx
                 signed_tx = signer.sign_transaction(tx)
                 signed_transactions.append(signed_tx.rawTransaction)
+            elif all(key in tx for key in ["v", "r", "s"]):
+                # transaction dict taken from w3.eth.get_block('pending', full_transactions=True)
+                v, r, s = (
+                    tx["v"],
+                    int(tx["r"].hex(), base=16),
+                    int(tx["s"].hex(), base=16),
+                )
+                raw = encode_transaction(
+                    Transaction(
+                        v=v,
+                        r=r,
+                        s=s,
+                        data=HexBytes(tx["input"]),
+                        gas=tx["gas"],
+                        gasPrice=tx["gasPrice"],
+                        nonce=tx["nonce"],
+                        to=HexBytes(tx["to"]),
+                        value=tx["value"],
+                    ),
+                    (v, r, s),
+                )
+                signed_transactions.append(raw)
 
         return signed_transactions
 

--- a/flashbots/types.py
+++ b/flashbots/types.py
@@ -1,6 +1,7 @@
 from eth_account.account import Account
 from web3.types import TxParams
 from typing import TypedDict, List
+from hexbytes import HexBytes
 
 FlashbotsBundleTx = TypedDict(
     "FlashbotsBundleTx",
@@ -14,6 +15,27 @@ FlashbotsBundleRawTx = TypedDict(
     "FlashbotsBundleRawTx",
     {
         "signed_transaction": str,
+    },
+)
+
+FlashbotsBundleDictTx = TypedDict(
+    "FlashbotsBundleDictTx",
+    {
+        "blockHash": HexBytes,
+        "blockNumber": int,
+        "from": str,
+        "gas": int,
+        "gasPrice": int,
+        "hash": HexBytes,
+        "input": str,
+        "nonce": int,
+        "r": HexBytes,
+        "s": HexBytes,
+        "to": str,
+        "transactionIndex": int,
+        "type": str,
+        "v": int,
+        "value": int,
     },
 )
 


### PR DESCRIPTION
Added support for transactions expressed as dictionaries, as provided by w3.eth.get_block('pending', full_transactions=True)

Example

`AttributeDict({'blockHash': HexBytes('0xe26e77c7426bb4b370dede3e6de140e67c2411e90813c3017ff2761a0e9420b8'), 'blockNumber': 10713060, 'from': '0x81F87187235223c2eb194EA63B2B292332EF8f82', 'gas': 134238, 'gasPrice': 10000000000, 'hash': HexBytes('0xbbd78a51741b3c972e646ac09b36441ed0dd3a023bbfb62d0d6de9da6f6319a9'), 'input': '0x7ff36ab500000000000000000000000000000000000000000000000000000000001b4139000000000000000000000000000000000000000000000000000000000000008000000000000000000000000081f87187235223c2eb194ea63b2b292332ef8f820000000000000000000000000000000000000000000000000000000061979f0d0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c778417e063141139fce010982780140aa0cd5ab000000000000000000000000dbc941fec34e8965ebc4a25452ae7519d6bdfc4e', 'nonce': 177917, 'r': HexBytes('0xa76ae800d6eaa9ba72589f0f94ac8cfeef182bb677f2f38768ba44bbf1bd45ca'), 's': HexBytes('0x535e932ef0d42fde8b40b2bee0672b07af03327b569d05a64fbef622cd74d811'), 'to': '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D', 'transactionIndex': 0, 'type': '0x0', 'v': 42, 'value': 729641236761779})`

