### PR TITLE
Adding flashbot stats RPCs

### DIFF
--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -23,6 +23,7 @@ class FlashbotsRPC:
     eth_sendBundle = RPCEndpoint("eth_sendBundle")
     eth_callBundle = RPCEndpoint("eth_callBundle")
     flashbots_getUserStats = RPCEndpoint("flashbots_getUserStats")
+    flashbots_getBundleStats = RPCEndpoint("flashbots_getBundleStats")
 
 
 class FlashbotsTransactionResponse:
@@ -259,3 +260,19 @@ class Flashbots(Module):
     )
 
     get_user_stats = getUserStats
+
+    def get_bundle_stats_munger(
+        self, bundle_hash: Union[str, int], block_number: Union[str, int]
+    ) -> List:
+        if isinstance(bundle_hash, int):
+            bundle_hash = hex(bundle_hash)
+        if isinstance(block_number, int):
+            block_number = hex(block_number)
+        return [{"bundleHash": bundle_hash, "blockNumber": block_number}]
+
+    getBundleStats: Method[Callable[[Any], Any]] = Method(
+        json_rpc_method=FlashbotsRPC.flashbots_getBundleStats,
+        mungers=[get_bundle_stats_munger],
+    )
+
+    get_bundle_stats = getBundleStats

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -22,6 +22,7 @@ SECONDS_PER_BLOCK = 15
 class FlashbotsRPC:
     eth_sendBundle = RPCEndpoint("eth_sendBundle")
     eth_callBundle = RPCEndpoint("eth_callBundle")
+    flashbots_getUserStats = RPCEndpoint("flashbots_getUserStats")
 
 
 class FlashbotsTransactionResponse:
@@ -248,3 +249,13 @@ class Flashbots(Module):
     call_bundle: Method[Callable[[Any], Any]] = Method(
         json_rpc_method=FlashbotsRPC.eth_callBundle, mungers=[call_bundle_munger]
     )
+
+    def get_user_stats_munger(self) -> List:
+        return [{"blockNumber": hex(self.web3.eth.blockNumber)}]
+
+    getUserStats: Method[Callable[[Any], Any]] = Method(
+        json_rpc_method=FlashbotsRPC.flashbots_getUserStats,
+        mungers=[get_user_stats_munger],
+    )
+
+    get_user_stats = getUserStats

--- a/flashbots/middleware.py
+++ b/flashbots/middleware.py
@@ -5,7 +5,12 @@ from web3.types import RPCEndpoint, RPCResponse
 from typing import Any
 from .provider import FlashbotProvider
 
-FLASHBOTS_METHODS = ["eth_sendBundle", "eth_callBundle", "flashbots_getUserStats"]
+FLASHBOTS_METHODS = [
+    "eth_sendBundle",
+    "eth_callBundle",
+    "flashbots_getUserStats",
+    "flashbots_getBundleStats",
+]
 
 
 def construct_flashbots_middleware(

--- a/flashbots/middleware.py
+++ b/flashbots/middleware.py
@@ -5,10 +5,7 @@ from web3.types import RPCEndpoint, RPCResponse
 from typing import Any
 from .provider import FlashbotProvider
 
-FLASHBOTS_METHODS = [
-    "eth_sendBundle",
-    "eth_callBundle",
-]
+FLASHBOTS_METHODS = ["eth_sendBundle", "eth_callBundle", "flashbots_getUserStats"]
 
 
 def construct_flashbots_middleware(


### PR DESCRIPTION
This PR adds support for `get_user_stats` and `get_bundle_stats` [RPC](https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint) methods. Example:
```python
w3.flashbots.get_user_stats() 
w3.flashbots.get_bundle_stats("0xb16203dfccb998a288f5ac6a64450c4f7d9bdd550285fc71d119cc11611517be", 13004595)
```

Closes #28.