### PR TITLE
Raise NotImplementedError when user sends private transaction to Goerli endpoint

### DIFF
--- a/flashbots/provider.py
+++ b/flashbots/provider.py
@@ -48,6 +48,11 @@ class FlashbotProvider(HTTPProvider):
             "X-Flashbots-Signature": f"{self.signature_account.address}:{signed_message.signature.hex()}"
         }
 
+        if ("goerli" in self.endpoint_uri) and (method == "eth_sendPrivateTransaction"):
+            raise NotImplementedError(
+                "eth_sendPrivateTransaction is not supported on Goerli Endpoint"
+            )
+
         raw_response = make_post_request(
             self.endpoint_uri, request_data, headers=headers
         )


### PR DESCRIPTION
Raise NotImplementedError when user sends private transaction to Goerli endpoint.
cfr https://github.com/flashbots/web3-flashbots/issues/54#issuecomment-1133946629

I think this will be more helpful than just letting the endpoint reply with a 400 client error.