### PR TITLE
adding extra delay to give web3 providers more time to synch and load…

### DIFF
--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -96,7 +96,8 @@ class FlashbotsPrivateTransactionResponse:
                 self.w3.eth.get_transaction(self.tx["hash"])
                 return True
             except TransactionNotFound:
-                if self.w3.eth.block_number > self.max_block_number:
+                # Add 1 to give web3 provider more time to sync and cache transactions
+                if self.w3.eth.block_number > self.max_block_number + 1:
                     return False
                 time.sleep(1)
 


### PR DESCRIPTION
Added an extra delay to the code that checks for bundle inclusion. I have encountered bugs where the TransactionNotFound error is raised even when my bundles land on chain. 

This suggests that web3 providers sometimes update the value returned by 'w3.eth.block.number' before the 'w3.eth.get_transaction()' endpoint is aware of all transaction hashes from a recent block. 

This may cause an issue where end-users send the same bundle twice because they do not receive proper confirmation. 