### PR TITLE
Support web3.py v6

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -37,7 +37,7 @@ def main() -> None:
     # account to send the transfer and sign transactions
     sender: LocalAccount = Account.from_key(env("ETH_SENDER_KEY"))
     # account to receive the transfer
-    receiverAddress: str = random_account().address
+    receiverAddress = random_account().address
     # account to sign bundles & establish flashbots reputation
     # NOTE: this account should not store funds
     signer: LocalAccount = Account.from_key(env("ETH_SIGNER_KEY"))
@@ -51,10 +51,10 @@ def main() -> None:
     print(f"Sender address: {sender.address}")
     print(f"Receiver address: {receiverAddress}")
     print(
-        f"Sender account balance: {Web3.fromWei(w3.eth.get_balance(sender.address), 'ether')} ETH"
+        f"Sender account balance: {Web3.from_wei(w3.eth.get_balance(sender.address), 'ether')} ETH"
     )
     print(
-        f"Receiver account balance: {Web3.fromWei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
+        f"Receiver account balance: {Web3.from_wei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
     )
 
     # bundle two EIP-1559 (type 2) transactions, pre-sign one of them
@@ -64,10 +64,10 @@ def main() -> None:
     nonce = w3.eth.get_transaction_count(sender.address)
     tx1: TxParams = {
         "to": receiverAddress,
-        "value": Web3.toWei(0.001, "ether"),
+        "value": Web3.to_wei(0.001, "ether"),
         "gas": 21000,
-        "maxFeePerGas": Web3.toWei(200, "gwei"),
-        "maxPriorityFeePerGas": Web3.toWei(50, "gwei"),
+        "maxFeePerGas": Web3.to_wei(200, "gwei"),
+        "maxPriorityFeePerGas": Web3.to_wei(50, "gwei"),
         "nonce": nonce,
         "chainId": CHAIN_ID,
         "type": 2,
@@ -76,10 +76,10 @@ def main() -> None:
 
     tx2: TxParams = {
         "to": receiverAddress,
-        "value": Web3.toWei(0.001, "ether"),
+        "value": Web3.to_wei(0.001, "ether"),
         "gas": 21000,
-        "maxFeePerGas": Web3.toWei(200, "gwei"),
-        "maxPriorityFeePerGas": Web3.toWei(50, "gwei"),
+        "maxFeePerGas": Web3.to_wei(200, "gwei"),
+        "maxPriorityFeePerGas": Web3.to_wei(50, "gwei"),
         "nonce": nonce + 1,
         "chainId": CHAIN_ID,
         "type": 2,
@@ -111,15 +111,15 @@ def main() -> None:
             target_block_number=block + 1,
             opts={"replacementUuid": replacement_uuid},
         )
-        print("bundleHash", w3.toHex(send_result.bundle_hash()))
+        print("bundleHash", w3.to_hex(send_result.bundle_hash()))
 
         stats_v1 = w3.flashbots.get_bundle_stats(
-            w3.toHex(send_result.bundle_hash()), block
+            w3.to_hex(send_result.bundle_hash()), block
         )
         print("bundleStats v1", stats_v1)
 
         stats_v2 = w3.flashbots.get_bundle_stats_v2(
-            w3.toHex(send_result.bundle_hash()), block
+            w3.to_hex(send_result.bundle_hash()), block
         )
         print("bundleStats v2", stats_v2)
 
@@ -135,10 +135,10 @@ def main() -> None:
             print(f"canceled {cancel_res}")
 
     print(
-        f"Sender account balance: {Web3.fromWei(w3.eth.get_balance(sender.address), 'ether')} ETH"
+        f"Sender account balance: {Web3.from_wei(w3.eth.get_balance(sender.address), 'ether')} ETH"
     )
     print(
-        f"Receiver account balance: {Web3.fromWei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
+        f"Receiver account balance: {Web3.from_wei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
     )
 
 

--- a/flashbots/provider.py
+++ b/flashbots/provider.py
@@ -21,11 +21,11 @@ class FlashbotProvider(HTTPProvider):
     logger = logging.getLogger("web3.providers.FlashbotProvider")
 
     def __init__(
-        self,
-        signature_account: LocalAccount,
-        endpoint_uri: Optional[Union[URI, str]] = None,
-        request_kwargs: Optional[Any] = None,
-        session: Optional[Any] = None,
+            self,
+            signature_account: LocalAccount,
+            endpoint_uri: Optional[Union[URI, str]] = None,
+            request_kwargs: Optional[Any] = None,
+            session: Optional[Any] = None,
     ):
         _endpoint_uri = endpoint_uri or get_default_endpoint()
         super().__init__(_endpoint_uri, request_kwargs, session)
@@ -41,12 +41,13 @@ class FlashbotProvider(HTTPProvider):
             text=Web3.keccak(text=request_data.decode("utf-8")).hex()
         )
         signed_message = Account.sign_message(
-            message, private_key=self.signature_account.privateKey.hex()
+            message, private_key=self.signature_account.key.hex()
         )
-
-        headers = self.get_request_headers() | {
-            "X-Flashbots-Signature": f"{self.signature_account.address}:{signed_message.signature.hex()}"
-        }
+        # headers = self.get_request_headers() | {
+        #     "X-Flashbots-Signature": f"{self.signature_account.address}:{signed_message.signature.hex()}"
+        # }
+        headers = self.get_request_headers()
+        headers["X-Flashbots-Signature"] = f"{self.signature_account.address}:{signed_message.signature.hex()}"
 
         if ("goerli" in self.endpoint_uri) and (method == "eth_sendPrivateTransaction"):
             raise NotImplementedError(

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ packages = ["flashbots"]
 
 package_data = {"": ["*"]}
 
-install_requires = ["web3>=5.22.0,<6"]
+install_requires = ["web3>=6,<7"]
 
 setup_kwargs = {
     "name": "flashbots",
-    "version": "1.1.1",
+    "version": "2.0.0",
     "description": "web3-flashbots.py",
     "long_description": 'This library works by injecting flashbots as a new module in the Web3.py instance, which allows submitting "bundles" of transactions directly to miners. This is done by also creating a middleware which captures calls to `eth_sendBundle` and `eth_callBundle`, and sends them to an RPC endpoint which you have specified, which corresponds to `mev-geth`.\n\nTo apply correct headers we use the `flashbot` method which injects the correct header on POST.\n\n## Quickstart\n\n```python\nfrom eth_account.signers.local import LocalAccount\nfrom web3 import Web3, HTTPProvider\nfrom flashbots import flashbot\nfrom eth_account.account import Account\nimport os\n\nETH_ACCOUNT_SIGNATURE: LocalAccount = Account.from_key(os.environ.get("ETH_SIGNATURE_KEY"))\n\n\nw3 = Web3(HTTPProvider("http://localhost:8545"))\nflashbot(w3, ETH_ACCOUNT_SIGNATURE)\n```\n\nNow the `w3.flashbots.sendBundle` method should be available to you. Look in [examples/simple.py](./examples/simple.py) for usage examples.\n\n### Goerli\n\nTo use goerli, add the goerli relay RPC to the `flashbot` function arguments.\n\n```python\nflashbot(w3, ETH_ACCOUNT_SIGNATURE, "https://relay-goerli.flashbots.net")\n```\n\n## Development and testing\n\nInstall [poetry](https://python-poetry.org/)\n\nPoetry will automatically fix your venv and all packages needed.\n\n```sh\npoetry install\n```\n\nTips: PyCharm has a poetry plugin\n\n## Simple Goerli Example\n\nSee [examples/simple.py](./examples/simple.py) for environment variable definitions.\n\n```sh\npoetry shell\nETH_SENDER_KEY=<sender_private_key> \\nPROVIDER_URL=https://eth-goerli.alchemyapi.io/v2/<alchemy_key> \\nETH_SIGNER_KEY=<signer_private_key> \\npython examples/simple.py\n```\n\n## Linting\n\nIt\'s advisable to run black with default rules for linting\n\n```sh\nsudo pip install black # Black should be installed with a global entrypoint\nblack .\n```',
     "long_description_content_type": "text/markdown",


### PR DESCRIPTION
1, change the function in web3py to the latest version 2, block the type of tx in FlashbotsPrivateTransactionResponse class 3, Flashbots class set the type of w3
```
is_async = False
w3: "Web3"
```
4, headers in provider.py is set by
```
headers = self.get_request_headers() | {
            "X-Flashbots-Signature": f"{self.signature_account.address}:{signed_message.signature.hex()}"
        }
``` 
modified to 
```
headers = self.get_request_headers()
headers["X-Flashbots-Signature"] = f"{self.signature_account.address}:{signed_message.signature.hex()}" 
```
to be compatible with python versions up to 3.9

Untested changes
1, cancel_private_transaction_munger class return value type 2, mask the type of signed_transaction in the send_private_transaction_munger method