### PR TITLE
Update web3py to version 6 and simplify example/simple.py 

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -11,17 +11,20 @@ Environment Variables:
 
 import os
 import secrets
+from traceback import print_exc
 from uuid import uuid4
+
 from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
-from flashbots import flashbot
-from web3 import Web3, HTTPProvider
+from web3 import HTTPProvider, Web3
 from web3.exceptions import TransactionNotFound
 from web3.types import TxParams
 
+from flashbots import flashbot
+
 # change this to `False` if you want to use mainnet
 USE_GOERLI = True
-CHAIN_ID = 5 if USE_GOERLI else 1
+CHAIN_ID = 11155111 if USE_GOERLI else 1
 
 
 def env(key: str) -> str:
@@ -37,24 +40,25 @@ def main() -> None:
     # account to send the transfer and sign transactions
     sender: LocalAccount = Account.from_key(env("ETH_SENDER_KEY"))
     # account to receive the transfer
-    receiverAddress: str = random_account().address
+    # receiverAddress: str = random_account().address
+    receiverAddress: str = sender.address
     # account to sign bundles & establish flashbots reputation
     # NOTE: this account should not store funds
     signer: LocalAccount = Account.from_key(env("ETH_SIGNER_KEY"))
 
     w3 = Web3(HTTPProvider(env("PROVIDER_URL")))
     if USE_GOERLI:
-        flashbot(w3, signer, "https://relay-goerli.flashbots.net")
+        flashbot(w3, signer, "https://relay-sepolia.flashbots.net")
     else:
         flashbot(w3, signer)
 
     print(f"Sender address: {sender.address}")
     print(f"Receiver address: {receiverAddress}")
     print(
-        f"Sender account balance: {Web3.fromWei(w3.eth.get_balance(sender.address), 'ether')} ETH"
+        f"Sender account balance: {Web3.from_wei(w3.eth.get_balance(sender.address), 'ether')} ETH"
     )
     print(
-        f"Receiver account balance: {Web3.fromWei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
+        f"Receiver account balance: {Web3.from_wei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
     )
 
     # bundle two EIP-1559 (type 2) transactions, pre-sign one of them
@@ -64,10 +68,10 @@ def main() -> None:
     nonce = w3.eth.get_transaction_count(sender.address)
     tx1: TxParams = {
         "to": receiverAddress,
-        "value": Web3.toWei(0.001, "ether"),
+        "value": Web3.to_wei(0.001, "ether"),
         "gas": 21000,
-        "maxFeePerGas": Web3.toWei(200, "gwei"),
-        "maxPriorityFeePerGas": Web3.toWei(50, "gwei"),
+        "maxFeePerGas": Web3.to_wei(1000, "gwei"),
+        "maxPriorityFeePerGas": Web3.to_wei(1000, "gwei"),
         "nonce": nonce,
         "chainId": CHAIN_ID,
         "type": 2,
@@ -76,10 +80,10 @@ def main() -> None:
 
     tx2: TxParams = {
         "to": receiverAddress,
-        "value": Web3.toWei(0.001, "ether"),
+        "value": Web3.to_wei(0.001, "ether"),
         "gas": 21000,
-        "maxFeePerGas": Web3.toWei(200, "gwei"),
-        "maxPriorityFeePerGas": Web3.toWei(50, "gwei"),
+        "maxFeePerGas": Web3.to_wei(1000, "gwei"),
+        "maxPriorityFeePerGas": Web3.to_wei(1000, "gwei"),
         "nonce": nonce + 1,
         "chainId": CHAIN_ID,
         "type": 2,
@@ -90,38 +94,28 @@ def main() -> None:
         {"signer": sender, "transaction": tx2},
     ]
 
+    # simulate bundle on current block
+    try:
+        block = w3.eth.block_number
+        w3.flashbots.simulate(bundle, block)
+        print("Simulation successful.")
+    except Exception as e:
+        print("Simulation error", e)
+        print_exc()
+        return
+
     # keep trying to send bundle until it gets mined
     while True:
+
         block = w3.eth.block_number
-        print(f"Simulating on block {block}")
-        # simulate bundle on current block
-        try:
-            w3.flashbots.simulate(bundle, block)
-            print("Simulation successful.")
-        except Exception as e:
-            print("Simulation error", e)
-            return
 
         # send bundle targeting next block
         print(f"Sending bundle targeting block {block+1}")
-        replacement_uuid = str(uuid4())
-        print(f"replacementUuid {replacement_uuid}")
         send_result = w3.flashbots.send_bundle(
             bundle,
             target_block_number=block + 1,
-            opts={"replacementUuid": replacement_uuid},
         )
-        print("bundleHash", w3.toHex(send_result.bundle_hash()))
-
-        stats_v1 = w3.flashbots.get_bundle_stats(
-            w3.toHex(send_result.bundle_hash()), block
-        )
-        print("bundleStats v1", stats_v1)
-
-        stats_v2 = w3.flashbots.get_bundle_stats_v2(
-            w3.toHex(send_result.bundle_hash()), block
-        )
-        print("bundleStats v2", stats_v2)
+        print("bundleHash", Web3.to_hex(send_result.bundle_hash()))
 
         send_result.wait()
         try:
@@ -131,14 +125,12 @@ def main() -> None:
         except TransactionNotFound:
             print(f"Bundle not found in block {block+1}")
             # essentially a no-op but it shows that the function works
-            cancel_res = w3.flashbots.cancel_bundles(replacement_uuid)
-            print(f"canceled {cancel_res}")
 
     print(
-        f"Sender account balance: {Web3.fromWei(w3.eth.get_balance(sender.address), 'ether')} ETH"
+        f"Sender account balance: {Web3.from_wei(w3.eth.get_balance(sender.address), 'ether')} ETH"
     )
     print(
-        f"Receiver account balance: {Web3.fromWei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
+        f"Receiver account balance: {Web3.from_wei(w3.eth.get_balance(receiverAddress), 'ether')} ETH"
     )
 
 

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -94,7 +94,7 @@ class FlashbotsPrivateTransactionResponse:
         self.max_block_number = max_block_number
         self.tx = {
             "signed_transaction": signed_tx,
-            "hash": self.w3.sha3(signed_tx),
+            "hash": self.w3.keccak(signed_tx),
         }
 
     def wait(self) -> bool:

--- a/flashbots/provider.py
+++ b/flashbots/provider.py
@@ -1,14 +1,13 @@
 import logging
 import os
-from typing import Any, Union, Optional
+from typing import Any, Optional, Union
 
 from eth_account import Account, messages
 from eth_account.signers.local import LocalAccount
 from eth_typing import URI
-from web3 import HTTPProvider
+from web3 import HTTPProvider, Web3
 from web3._utils.request import make_post_request
 from web3.types import RPCEndpoint, RPCResponse
-from web3 import Web3
 
 
 def get_default_endpoint() -> URI:
@@ -41,7 +40,7 @@ class FlashbotProvider(HTTPProvider):
             text=Web3.keccak(text=request_data.decode("utf-8")).hex()
         )
         signed_message = Account.sign_message(
-            message, private_key=self.signature_account.privateKey.hex()
+            message, private_key=self.signature_account._private_key.hex()
         )
 
         headers = self.get_request_headers() | {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 version = "1.1.1"
 
 [tool.poetry.dependencies]
-python = "^3.9"
-web3 = ">=5.22.0, <6"
+python = ">3.9"
+web3 = ">6,<7"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3"


### PR DESCRIPTION
1. update web3py to version 6 which is more popular now.
2. remove replacementid in example/simple.py to make the example work, there maybe a bug in replacementid staff in the code.