### PR TITLE
Add builders to opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+```
+pip install -U git+https://github.com/web3dev2023/web3-flashbots.git
+```
+
+
 # web3-flashbots
 
 This library works by injecting flashbots as a new module in the Web3.py instance, which allows submitting "bundles" of transactions directly to miners. This is done by also creating a middleware which captures calls to `eth_sendBundle` and `eth_callBundle`, and sends them to an RPC endpoint which you have specified, which corresponds to `mev-geth`.

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -228,6 +228,7 @@ class Flashbots(Module):
                 "replacementUuid": (
                     opts["replacementUuid"] if "replacementUuid" in opts else None
                 ),
+                "builders": opts["builders"] if "builders" in opts else ["flashbots"],
             }
         ]
 

--- a/flashbots/flashbots.py
+++ b/flashbots/flashbots.py
@@ -228,7 +228,9 @@ class Flashbots(Module):
                 "replacementUuid": (
                     opts["replacementUuid"] if "replacementUuid" in opts else None
                 ),
-                "builders": opts["builders"] if "builders" in opts else ["flashbots"],
+                "builders": opts["builders"] if "builders" in opts else ["flashbots", "f1b.io", "rsync", "beaverbuild.org", "builder0x69", "Titan", "EigenPhi", 
+                                                                 "boba-builder", "Gambit Labs", "payload", "Loki", "BuildAI", "JetBuilder", "tbuilder", 
+                                                                 "penguinbuild", "bobthebuilder", "BTCS", "bloXroute", "Blockbeelder", "Quasar", "Eureka"], #Based on https://github.com/flashbots/dowg/blob/main/builder-registrations.json
             }
         ]
 
@@ -424,6 +426,9 @@ class Flashbots(Module):
         params = {
             "tx": self.to_hex(signed_transaction),
             "maxBlockNumber": max_block_number,
+            "preferences": {"fast":True, "privacy":{"builders": ["flashbots", "f1b.io", "rsync", "beaverbuild.org", "builder0x69", "Titan", "EigenPhi", 
+                                                                 "boba-builder", "Gambit Labs", "payload", "Loki", "BuildAI", "JetBuilder", "tbuilder", 
+                                                                 "penguinbuild", "bobthebuilder", "BTCS", "bloXroute", "Blockbeelder", "Quasar", "Eureka"] }},
         }
         self.response = FlashbotsPrivateTransactionResponse(
             self.w3, signed_transaction, max_block_number

--- a/flashbots/types.py
+++ b/flashbots/types.py
@@ -57,6 +57,7 @@ FlashbotsOpts = TypedDict(
         "maxTimestamp": Optional[int],
         "revertingTxHashes": Optional[List[str]],
         "replacementUuid": Optional[str],
+        "builders": Optional[List[str]],
     },
 )
 


### PR DESCRIPTION
There are 7 parameters in the [eth_sendBundle](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_sendbundle) JSON-RPC method but only 6 of them are allowed to be set in opts. This merge simply adds support for setting `builders`